### PR TITLE
Ensure options are deep extended

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ module.exports = function (dest, ctx) {
   var def = require('./default.json');
 
   ctx.groups = extend(def.groups, ctx.groups);
+  ctx.display = extend(def.display, ctx.display);
   ctx = extend({}, def, ctx);
 
   if (!ctx.display) {


### PR DESCRIPTION
Was there a reason why deep extend was removed ?
https://github.com/SassDoc/sassdoc-theme-default/blob/develop/index.js#L37

So the user willing to override only specific options in its `.sassdocrc` or `--config` as in:

``` js
"display": {
  "watermark": false
}
```

is getting an Error:

```
[ERROR] TypeError: Cannot call method 'indexOf' of undefined
at /[...]/sassdoc-theme-default/node_modules/sassdoc-extras/src/display.js:9:48
```
