### PR TITLE
Don't capitalize the main heading

### DIFF
--- a/scss/partials/_main.scss
+++ b/scss/partials/_main.scss
@@ -33,7 +33,6 @@
   color: color("dark-grey");
   font-size: 4em;
   text-align: center;
-  text-transform: capitalize;
 
   border-bottom: 5px solid color("pink");
   padding-bottom: .5em;


### PR DESCRIPTION
A module name could be knowingly named in lowercase because of a specification, such as o-overlay, o-grid…

### Before

![ ](https://slack-files.com/files-tmb/T02RPVB53-F03EP4QGA-69ce061445/screenshot_2015-01-23_15.14.08_360.png)

### After

![ ](https://slack-files.com/files-tmb/T02RPVB53-F03EM12C5-8e1a4f4333/screenshot_2015-01-23_15.20.11_360.png)