### PR TITLE
[RFR] Change Google Analytics code to Universal Analytics

### DIFF
--- a/views/includes/partials/scripts.html.swig
+++ b/views/includes/partials/scripts.html.swig
@@ -2,13 +2,14 @@
 <script>window.jQuery || document.write('<script src="assets/js/vendor/jquery.min.js"><\/script>')</script>
 {% if googleAnalytics %}
 <script>
-  var _gaq = [['_setAccount', '{{ googleAnalytics }}'], ['_trackPageview']];
-  (function(d) {
-    var g = d.createElement('script'),
-        s = d.scripts[0];
-    g.src = '//ssl.google-analytics.com/ga.js';
-    s.parentNode.insertBefore(g, s);
-  }(document));
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', '{{ googleAnalytics }}', 'auto');
+  ga('send', 'pageview');
+
 </script>
 {% endif %}
 {% if trackingCode %}


### PR DESCRIPTION
Update Google Analytics code to use [Universal Analytics](https://support.google.com/analytics/answer/2790010?hl=en-GB). It's the most recent tracking code from Google and is the one provided when a new Analytics account is created.