### PR TITLE
[RFR] Add Open Graph tags

### DIFF
--- a/views/includes/partials/head.html.swig
+++ b/views/includes/partials/head.html.swig
@@ -6,6 +6,16 @@
 <meta name="viewport" content="width=device-width">
 <meta content="IE=edge, chrome=1" http-equiv="X-UA-Compatible">
 
+<!-- Open Graph tags -->
+<meta property="og:title" content="{{ project_title }} - SassDoc" />
+<meta property="og:type" content="website" />
+
+{% if package.description %}
+<meta property="og:description" content="{{ package.description | safe }}" />
+{% else %}
+<meta property="og:description" content="Release the docs!" />
+{% endif %}
+
 <!-- Thanks to Sass-lang.com for the icons -->
 {% if shortcutIcon.type == 'internal' %}
 <link href="{{ base }}/{{ shortcutIcon.url }}" rel="shortcut icon">


### PR DESCRIPTION
It would be nice to add Open Graph tags (ideally title, type, description, image and url) to make the pages shareable. I didn't include `og:image` or `og:url` in this PR because:

1. Facebook doesn't allow SVG in `og:image`. Could we create a PNG version of `logo_full_compact.svg`?
2. Both `og:image` and `og:url` need an absolute URL. Is this information available anywhere?