### PR TITLE
[RFR] Include font antialiased for mac

### DIFF
--- a/scss/base/_base.scss
+++ b/scss/base/_base.scss
@@ -16,6 +16,9 @@ body {
   font: 1em/1.35 $text-font-stack;
   overflow: auto;
   margin: 0;
+  //better font render in mac
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 /**


### PR DESCRIPTION
I'm testing the sass docs and I am really enjoying using . But I missed these properties in default theme css to improve font rendering in Mac browsers like firefox and chrome . So I decided to include here . Congratulations for the great work !

```
-webkit-font-smoothing: antialiased;
-moz-osx-font-smoothing: grayscale;
```
