### PR TITLE
Use `es6-denodeify` instead of `promise-denodeify`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   "dependencies": {
     "6to5-runtime": "^3.2.1",
     "chroma-js": "^0.6.3",
+    "es6-denodeify": "^0.1.0",
     "extend": "^1.0.0",
     "fs-extra": "^0.16.3",
     "html-minifier": "^0.6.9",
-    "promise-denodeify": "^1.2.2",
     "sassdoc-extras": "^2.1.0",
     "swig": "1.4.0",
     "swig-extras": "^0.0.1"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import chroma from 'chroma-js';
 import def from '../default';
-import denodeify from 'promise-denodeify';
+import denodeify from 'es6-denodeify';
 import extend  from 'extend';
 import fs from 'fs';
 import fse from 'fs-extra';
@@ -9,9 +9,11 @@ import path from 'path';
 import sassdocExtras from 'sassdoc-extras';
 import swig from './swig';
 
-const copy = denodeify(fse.copy, Promise);
-const renderFile = denodeify(swig.renderFile, Promise);
-const writeFile = denodeify(fs.writeFile, Promise);
+denodeify = denodeify(Promise);
+
+const copy = denodeify(fse.copy);
+const renderFile = denodeify(swig.renderFile);
+const writeFile = denodeify(fs.writeFile);
 
 const applyDefaults = ctx =>
   extend({}, def, ctx, {


### PR DESCRIPTION
This avoids the deprecated warning during package installation.

* See SassDoc/sassdoc#366