### PR TITLE
Remove 6to5 runtime dependence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ dist: $(DIST)
 
 dist/%.js: src/%.js
 	mkdir -p $(@D)
-	6to5 --optional selfContained $< -o $@
+	6to5 $< -o $@
 
 min: assets/js/main.min.js
 

--- a/package.json
+++ b/package.json
@@ -25,15 +25,15 @@
     "6to5-runtime": "^3.2.1",
     "chroma-js": "^0.6.3",
     "es6-denodeify": "^0.1.0",
-    "extend": "^1.0.0",
+    "extend": "^2.0.0",
     "fs-extra": "^0.16.3",
-    "html-minifier": "^0.6.9",
+    "html-minifier": "^0.7.0",
     "sassdoc-extras": "^2.1.0",
     "swig": "1.4.0",
     "swig-extras": "^0.0.1"
   },
   "devDependencies": {
-    "6to5": "^3.2.1",
+    "6to5": "^3.6.0",
     "jshint": "^2.6.0",
     "uglify-js": "^2.4.15"
   }

--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
   ],
   "main": "dist",
   "dependencies": {
-    "6to5-runtime": "^3.2.1",
     "chroma-js": "^0.6.3",
     "es6-denodeify": "^0.1.0",
+    "es6-promise": "^2.0.1",
     "extend": "^2.0.0",
     "fs-extra": "^0.16.3",
     "html-minifier": "^0.7.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import chroma from 'chroma-js';
 import def from '../default';
+import { Promise } from 'es6-promise';
 import denodeify from 'es6-denodeify';
 import extend  from 'extend';
 import fs from 'fs';


### PR DESCRIPTION
- Since we don't use ES6 features requiring polyfills the default compilation is enough.
- Add `es6-promise` for Promises support
- Might be removed when node 0.12 reach more stability/widespread adoption.