### PR TITLE
Make loading of external resources protocol agnostic to prevent mixed content warnings

### DIFF
--- a/views/includes/partials/head.html.swig
+++ b/views/includes/partials/head.html.swig
@@ -2,7 +2,7 @@
 
 <title>{{ project_title }}{% if package.version %} - v{{ package.version }}{% endif %}</title>
 <link rel="stylesheet" href="assets/css/main.css" />
-<link href='//fonts.googleapis.com/css?family=Open+Sans:400,500,700' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,500,700' rel='stylesheet' type='text/css'>
 <meta name="viewport" content="width=device-width">
 <meta content="IE=edge, chrome=1" http-equiv="X-UA-Compatible">
 

--- a/views/includes/partials/head.html.swig
+++ b/views/includes/partials/head.html.swig
@@ -2,7 +2,7 @@
 
 <title>{{ project_title }}{% if package.version %} - v{{ package.version }}{% endif %}</title>
 <link rel="stylesheet" href="assets/css/main.css" />
-<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,500,700' rel='stylesheet' type='text/css'>
+<link href='//fonts.googleapis.com/css?family=Open+Sans:400,500,700' rel='stylesheet' type='text/css'>
 <meta name="viewport" content="width=device-width">
 <meta content="IE=edge, chrome=1" http-equiv="X-UA-Compatible">
 

--- a/views/includes/partials/scripts.html.swig
+++ b/views/includes/partials/scripts.html.swig
@@ -1,4 +1,4 @@
-<script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="assets/js/vendor/jquery.min.js"><\/script>')</script>
 {% if googleAnalytics %}
 <script>

--- a/views/includes/partials/scripts.html.swig
+++ b/views/includes/partials/scripts.html.swig
@@ -1,4 +1,4 @@
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="assets/js/vendor/jquery.min.js"><\/script>')</script>
 {% if googleAnalytics %}
 <script>


### PR DESCRIPTION
We are using your tool, but would love to be able to also serve it via https. This should fix it. :)