### PR TITLE
Adding simple support for plain css

### DIFF
--- a/views/includes/annotations/preview.html.swig
+++ b/views/includes/annotations/preview.html.swig
@@ -29,11 +29,12 @@
 
 {# Plain CSS #}
 {% elseif item.context.type == "css" %}
-
-<div class="item__code-wrapper">
-  <pre class="item__code  language-scss"><code>{{ item.context.name }} {
+  <pre class="item__code  item__code--togglable  language-scss"
+    data-current-state="collapsed"
+    data-expanded="<code>{{ item.context.name }} {
   {{ item.context.value }}
-}</code></pre>
+}</code>"
+    data-collapsed="{{ item.context.name }} { ... }"><code>{{ item.context.name }} { ... }</code></pre>
 </div>
 
 {# Functions and mixins #}

--- a/views/includes/annotations/preview.html.swig
+++ b/views/includes/annotations/preview.html.swig
@@ -29,6 +29,7 @@
 
 {# Plain CSS #}
 {% elseif item.context.type == "css" %}
+<div class="item__code-wrapper">
   <pre class="item__code  item__code--togglable  language-scss"
     data-current-state="collapsed"
     data-expanded="<code>{{ item.context.name }} {

--- a/views/includes/annotations/preview.html.swig
+++ b/views/includes/annotations/preview.html.swig
@@ -27,6 +27,15 @@
   {% endif %}
 </div>
 
+{# Plain CSS #}
+{% elseif item.context.type == "css" %}
+
+<div class="item__code-wrapper">
+  <pre class="item__code  language-scss"><code>{{ item.context.name }} {
+  {{ item.context.value }}
+}</code></pre>
+</div>
+
 {# Functions and mixins #}
 {% else %}
 

--- a/views/includes/partials/item.html.swig
+++ b/views/includes/partials/item.html.swig
@@ -12,6 +12,10 @@
     {% set path = '../annotations/' + annotation + '.html.swig' %}
     {% include path %}
   {% endfor %}
+  
+  {% if item.context.type == "css" %}
+    {% include '../annotations/description.html.swig' %}
+  {% endif %}
 
 {% else %}
 


### PR DESCRIPTION
I know that sassdoc is for sass and not css but I still would prefer this output for css because it allows to add some css classes as usage examples.

**Input**
```
/// This class should be used for text with the default
/// font size, font weight and font family.
/// @group fonts
.default-text {
  font-family: $font-family-text;
  font-weight: $font-weight-regular;
  font-size: $font-size-regular;
}
```

**Before**
![Imgur](http://i.imgur.com/B48HvrW.png)
**After**
![Imgur](http://i.imgur.com/3JTROnD.png)