### PR TITLE
Added the css type to the annotations array

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,7 +4,8 @@
       "function": ["description", "parameter", "return", "example", "throw", "require", "usedby", "since", "see", "todo", "link", "author"],
       "mixin": ["description", "parameter", "content", "example", "output", "throw", "require", "usedby", "since", "see", "todo", "link", "author"],
       "placeholder": ["description", "example", "throw", "require", "usedby", "since", "see", "todo", "link", "author"],
-      "variable": ["description", "type", "property", "require", "example", "usedby", "since", "see", "todo", "link", "author"]
+      "variable": ["description", "type", "property", "require", "example", "usedby", "since", "see", "todo", "link", "author"],
+      "css": ["description", "example", "since", "see", "todo", "link", "author"]
     },
     "access": ["public", "private"],
     "alias": false,

--- a/views/includes/partials/item.html.swig
+++ b/views/includes/partials/item.html.swig
@@ -12,10 +12,6 @@
     {% set path = '../annotations/' + annotation + '.html.swig' %}
     {% include path %}
   {% endfor %}
-  
-  {% if item.context.type == "css" %}
-    {% include '../annotations/description.html.swig' %}
-  {% endif %}
 
 {% else %}
 


### PR DESCRIPTION
This is related to #98 ... sorry for being late but I haven't recognized that I could add "css" to the default.json. This change cleans up the item.html.swig and allows to define other annotation elements for plain css (like "example" or "see").

Thank you for merging the prior PR :)