### PR TITLE
Fix pluralization in the easiest way (for now)

### DIFF
--- a/src/swig.js
+++ b/src/swig.js
@@ -43,6 +43,12 @@ const hexToRgb = hex =>
 const colorToHex = color =>
   chroma(color).hex().substr(1)
 
+const pluralize = input =>
+  input.toLowerCase()
+    .substring(input.length - 1) === 's'
+      ? input
+      : input + 's'
+
 /**
  * Normalises a CSS color, then uses the YIQ algorithm to get the
  * correct contrast.
@@ -60,3 +66,4 @@ swig.setFilter('in', (key, object) => key in object)
 swig.setFilter('is_color', isColor)
 swig.setFilter('display_as_type', safe(displayAsType))
 swig.setFilter('yiq', maybeYiqContrast)
+swig.setFilter('pluralize', pluralize)

--- a/views/documentation/index.html.swig
+++ b/views/documentation/index.html.swig
@@ -28,7 +28,7 @@
             <section class="main__sub-section" id="{{ group_name }}-{{ type }}">
               <h2 class="main__heading--secondary">
                 <div class="container">
-                  {{ (type + 's') }}
+                  {{ type | pluralize }}
                 </div>
               </h2>
 

--- a/views/includes/partials/sidebar.html.swig
+++ b/views/includes/partials/sidebar.html.swig
@@ -27,7 +27,7 @@
 
         {# If items to be displayed in type #}
         {% if items.length > 0 %}
-          <p class="sidebar__item  sidebar__item--sub-heading" data-slug="{{ group_name + '-' + type }}"><a href="#{{ group_name }}-{{ type }}">{{ (type + 's') }}</a></p>
+          <p class="sidebar__item  sidebar__item--sub-heading" data-slug="{{ group_name + '-' + type }}"><a href="#{{ group_name }}-{{ type }}">{{ type | pluralize }}</a></p>
 
           {# Loop over the items #}
           {% for item in items %}


### PR DESCRIPTION
In the future, we could use a pluralization library, but for now, we're just checking if the word we want to pluralize ends on a 's'. Everything else might be overkill too, since we have a non-arbitrary amount of phrases we use for headlines/pluralisation.