### PR TITLE
add item.group to the name annotation link

### DIFF
--- a/views/includes/annotations/name.html.njk
+++ b/views/includes/annotations/name.html.njk
@@ -3,20 +3,20 @@
     <span class="item__access">[{{ item.access }}]</span>
   {% endif %}
 
-  <a class="item__name" href="#{{ item.context.type }}-{{ item.context.name }}">
+  <a class="item__name" href="#{{ item.group }}-{{ item.context.type }}-{{ item.context.name }}">
     {{ item.context.name | unescape }}
   </a>
 
   {% if display.alias and item.aliased.length > 0 %}
     <span class="item__aliased">(aliased as
     {% for alias in item.aliased %}
-      <a href="#{{ item.context.type }}-{{ alias }}"><code>{{ alias }}</code></a>
+      <a href="#{{ item.group }}-{{ item.context.type }}-{{ alias }}"><code>{{ alias }}</code></a>
     {% endfor %}
     )</span>
   {% endif %}
 
   {% if item.alias %}
-    <span class="item__alias">(alias for <a href="#{{ item.context.type }}-{{ item.alias }}"><code>{{ item.alias }}</code></a>)</span>
+    <span class="item__alias">(alias for <a href="#{{ item.group }}-{{ item.context.type }}-{{ item.alias }}"><code>{{ item.alias }}</code></a>)</span>
   {% endif %}
 </h3>
 


### PR DESCRIPTION
The "group" value for an item does not get inserted into the item's link.
This means that clicking on an item's name h3 results in the wrong anchor string, so the page does not jump to that item and deep linking to that item doesn't work.

The sidebar and search result links correctly prepend the group to the link.

### Example
Given the following sass
```sass
/// @group helpers
.foobar {display: none;}
```

the h3 for foobar will contain `<a class="item__name" href="#css-.foobar">`.
This is incorrect, it should be `<a class="item__name" href="#helpers-css-.foobar">`. 

Related to https://github.com/SassDoc/sassdoc/issues/575.